### PR TITLE
Play updates for music changes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import { Command } from 'commander';
+import { UserControls } from './user-controls/UserControls';
 import { YTMusicSession } from './yt-music/YTMusicSession';
 
 const program = new Command();
@@ -21,4 +22,5 @@ const headless = true && options.headless;
   const ytMusicSession = await YTMusicSession.create(program.args, {
     headless,
   });
+  const userControls = new UserControls(ytMusicSession);
 })();

--- a/src/user-controls/BrowserSession.ts
+++ b/src/user-controls/BrowserSession.ts
@@ -1,3 +1,8 @@
+import { PlaybackControls } from './PlaybackControls';
+import { PlayUpdates } from './PlayUpdates';
+
 export interface BrowserSession {
   search: (args: string[]) => Promise<void>;
+  PlaybackControls: PlaybackControls;
+  PlayUpdates: PlayUpdates;
 }

--- a/src/user-controls/BrowserSession.ts
+++ b/src/user-controls/BrowserSession.ts
@@ -1,0 +1,3 @@
+export interface BrowserSession {
+  search: (args: string[]) => Promise<void>;
+}

--- a/src/user-controls/PlayUpdates.ts
+++ b/src/user-controls/PlayUpdates.ts
@@ -1,0 +1,7 @@
+export type PlayUpdateSubscriber = (nowPlaying: string) => void;
+
+export interface PlayUpdates {
+  nowPlaying: string;
+  subscribe: (callback: PlayUpdateSubscriber) => void;
+  forceSongUpdate: () => void;
+}

--- a/src/user-controls/PlaybackControls.ts
+++ b/src/user-controls/PlaybackControls.ts
@@ -1,0 +1,6 @@
+import { PromptChoice } from './PromptChoice';
+
+export interface PlaybackControls {
+  execute: (control: any) => Promise<void>;
+  controlActions: PromptChoice[];
+}

--- a/src/user-controls/PromptChoice.ts
+++ b/src/user-controls/PromptChoice.ts
@@ -1,0 +1,4 @@
+export interface PromptChoice {
+  name: string;
+  value: () => void;
+}

--- a/src/user-controls/UserControls.ts
+++ b/src/user-controls/UserControls.ts
@@ -1,0 +1,25 @@
+import { BrowserSession } from './BrowserSession';
+import inquirer from 'inquirer';
+export class UserControls {
+  constructor(private session: BrowserSession) {
+    this.basicPrompt();
+  }
+
+  async basicPrompt() {
+    const basicControls = await inquirer.prompt([
+      {
+        type: 'list',
+        name: 'control',
+        message: this.session.PlayUpdates.nowPlaying,
+        choices: this.getChoices(),
+      },
+    ]);
+
+    basicControls.control();
+    this.basicPrompt();
+  }
+
+  getChoices() {
+    return this.session.PlaybackControls.controlActions;
+  }
+}

--- a/src/user-controls/UserControls.ts
+++ b/src/user-controls/UserControls.ts
@@ -1,12 +1,22 @@
 import { BrowserSession } from './BrowserSession';
-import inquirer from 'inquirer';
+import inquirer, { PromptModule } from 'inquirer';
+import { Subject } from 'rxjs';
 export class UserControls {
+  private isSwitchingSongs = false;
+
   constructor(private session: BrowserSession) {
     this.basicPrompt();
+
+    this.session.PlayUpdates.subscribe((song) => {
+      if (!this.isSwitchingSongs) this.basicPrompt();
+    });
   }
 
   async basicPrompt() {
-    const basicControls = await inquirer.prompt([
+    process.stdout.moveCursor(0, -1);
+    process.stdout.clearLine(1);
+
+    const userResponse = await inquirer.prompt([
       {
         type: 'list',
         name: 'control',
@@ -14,12 +24,16 @@ export class UserControls {
         choices: this.getChoices(),
       },
     ]);
+    userResponse.control();
 
-    basicControls.control();
-    this.basicPrompt();
+    this.isSwitchingSongs = true;
+    setTimeout(() => {
+      this.isSwitchingSongs = false;
+      this.basicPrompt();
+    }, 500);
   }
 
   getChoices() {
-    return this.session.PlaybackControls.controlActions;
+    return [...this.session.PlaybackControls.controlActions];
   }
 }

--- a/src/yt-music/YTMusicPlaybackControls.ts
+++ b/src/yt-music/YTMusicPlaybackControls.ts
@@ -1,0 +1,20 @@
+import { Page } from 'puppeteer';
+
+/**
+ * An enum for the different types of controls that map to the appropriate selector in the DOM.
+ */
+enum PlaybackControl {
+  Play = `#play-pause-button`,
+  Pause = `#play-pause-button`,
+  Next = `tp-yt-paper-icon-button[title="Next song"]`,
+  Previous = `tp-yt-paper-icon-button[title="Previous song"]`,
+}
+
+export class YTMusicPlaybackControls {
+  constructor(private page: Page) {}
+
+  public async executeControl(control: PlaybackControl) {
+    await this.page.waitForSelector(control);
+    await this.page.click(control);
+  }
+}

--- a/src/yt-music/YTMusicPlaybackControls.ts
+++ b/src/yt-music/YTMusicPlaybackControls.ts
@@ -1,20 +1,28 @@
 import { Page } from 'puppeteer';
+import { PlaybackControls } from '../user-controls/PlaybackControls';
 
 /**
  * An enum for the different types of controls that map to the appropriate selector in the DOM.
  */
-enum PlaybackControl {
-  Play = `#play-pause-button`,
-  Pause = `#play-pause-button`,
+export enum YTControl {
+  PlayPause = `#play-pause-button`,
   Next = `tp-yt-paper-icon-button[title="Next song"]`,
   Previous = `tp-yt-paper-icon-button[title="Previous song"]`,
 }
 
-export class YTMusicPlaybackControls {
+export class YTMusicPlaybackControls implements PlaybackControls {
   constructor(private page: Page) {}
 
-  public async executeControl(control: PlaybackControl) {
+  public async execute(control: YTControl) {
     await this.page.waitForSelector(control);
     await this.page.click(control);
+  }
+
+  public get controlActions() {
+    return [
+      { name: 'Play/Pause', value: () => this.execute(YTControl.PlayPause) },
+      { name: 'Next Song', value: () => this.execute(YTControl.Next) },
+      { name: 'Previous Song', value: () => this.execute(YTControl.Previous) },
+    ];
   }
 }

--- a/src/yt-music/YTMusicSearchOptions.ts
+++ b/src/yt-music/YTMusicSearchOptions.ts
@@ -1,4 +1,7 @@
 export interface YTSearchOptions {
+  /**
+   * When set to true, the first search result will automatically be activated. Similar to Google's "I'm feeling lucky" button. Default is true.
+   */
   activateFirstResult: boolean;
 }
 
@@ -6,6 +9,11 @@ export const defaultYTSearchOptions: YTSearchOptions = {
   activateFirstResult: true,
 };
 
+/**
+ * Merges any passed in YTSearchOptions with the default, overriding any default options.
+ * @param ytSearchOptions A partial object containing the default properties that should be overriden.
+ * @returns An updated complete YTSearchOptions object with all properties assigned.
+ */
 export const mergeDefaultYTSearchOptions = (
   ytSearchOptions?: Partial<YTSearchOptions>
 ): YTSearchOptions => {

--- a/src/yt-music/YTMusicSession.ts
+++ b/src/yt-music/YTMusicSession.ts
@@ -10,11 +10,14 @@ import {
   YTSessionOptions,
 } from './YTSessionOptions';
 import { YTPlayUpdates } from './YTPlayUpdates';
+import { BrowserSession } from '../user-controls/BrowserSession';
+import { YTMusicPlaybackControls } from './YTMusicPlaybackControls';
 
 const YOUTUBE_MUSIC_URL = 'https://music.youtube.com/';
 
 export class YTMusicSession {
   public PlayUpdates: YTPlayUpdates;
+  public PlaybackControls: YTMusicPlaybackControls;
 
   /**
    * A YTMusicSession instance manages all headless browsing of the Youtube Music website. A YTMusicSession must be instantiated asynchronously via the 'create' function.

--- a/src/yt-music/YTMusicSession.ts
+++ b/src/yt-music/YTMusicSession.ts
@@ -24,7 +24,7 @@ export class YTMusicSession implements BrowserSession {
    * @param page An initialized Puppeteer page used to navigate Youtube music.
    */
   private constructor(private page: Page) {
-    this.PlayUpdates = new YTPlayUpdates(page, [(song) => console.log(song)]);
+    this.PlayUpdates = new YTPlayUpdates(page);
     this.PlaybackControls = new YTMusicPlaybackControls(page);
   }
 

--- a/src/yt-music/YTMusicSession.ts
+++ b/src/yt-music/YTMusicSession.ts
@@ -13,7 +13,19 @@ import {
 const YOUTUBE_MUSIC_URL = 'https://music.youtube.com/';
 
 export class YTMusicSession {
-  private constructor(private page: Page) {}
+  private playUpdateSubscribers = [];
+
+  private currentSong: string = '';
+  private currentArtist: string = '';
+
+  public get nowPlaying() {
+    return `${this.currentSong} | ${this.currentArtist}`;
+  }
+
+  private constructor(private page: Page) {
+    this.subscribePlayUpdates((song) => console.log('Now playing: ', song));
+    this.handlePlayUpdate();
+  }
 
   static async create(
     args?: string[],
@@ -66,5 +78,62 @@ export class YTMusicSession {
     const nextSongSelector = `tp-yt-paper-icon-button[title="Next song"]`;
     await this.page.waitForSelector(nextSongSelector);
     await this.page.click(nextSongSelector);
+  }
+
+  public async previousSong() {
+    const previousSongSelector = `tp-yt-paper-icon-button[title="Previous song"]`;
+    await this.page.waitForSelector(previousSongSelector);
+    await this.page.click(previousSongSelector);
+  }
+
+  public async playPause() {
+    const playPauseSelector = `#play-pause-button`;
+    await this.page.waitForSelector(playPauseSelector);
+    await this.page.click(playPauseSelector);
+  }
+
+  public subscribePlayUpdates = (callback: (nowPlaying: string) => void) => {
+    this.playUpdateSubscribers.push(callback);
+  };
+
+  private async handlePlayUpdate() {
+    await this.page.exposeFunction(
+      'handlePlayUpdate',
+      (newSongInfo: string, newArtistInfo: string) => {
+        this.currentSong = newSongInfo;
+        this.currentArtist = newArtistInfo;
+        this.playUpdateSubscribers.forEach((subscriber) =>
+          subscriber(this.nowPlaying)
+        );
+      }
+    );
+    await Promise.all([
+      this.page.waitForSelector(`ytmusic-player-bar yt-formatted-string`),
+      this.page.waitForSelector(
+        `ytmusic-player-bar span.subtitle yt-formatted-string a`
+      ),
+    ]);
+
+    await this.page.evaluate(() => {
+      const observer = new MutationObserver(() => {
+        const newSongElement: HTMLElement = document.querySelector(
+          `ytmusic-player-bar yt-formatted-string`
+        );
+        const newArtistElement: HTMLElement = document.querySelector(
+          `ytmusic-player-bar span.subtitle yt-formatted-string a`
+        );
+
+        //@ts-ignore
+        handlePlayUpdate(newSongElement.innerText, newArtistElement.innerText);
+      });
+      observer.observe(
+        document.querySelector(`ytmusic-player-bar yt-formatted-string`),
+        {
+          attributes: false,
+          childList: true,
+          subtree: true,
+        }
+      );
+    });
   }
 }

--- a/src/yt-music/YTMusicSession.ts
+++ b/src/yt-music/YTMusicSession.ts
@@ -22,6 +22,7 @@ export class YTMusicSession {
    */
   private constructor(private page: Page) {
     this.PlayUpdates = new YTPlayUpdates(page, [(song) => console.log(song)]);
+    this.PlaybackControls = new YTMusicPlaybackControls(page);
   }
 
   /**
@@ -82,23 +83,5 @@ export class YTMusicSession {
     ]);
 
     await this.PlayUpdates.forceSongUpdate();
-  }
-
-  public async nextSong() {
-    const nextSongSelector = `tp-yt-paper-icon-button[title="Next song"]`;
-    await this.page.waitForSelector(nextSongSelector);
-    await this.page.click(nextSongSelector);
-  }
-
-  public async previousSong() {
-    const previousSongSelector = `tp-yt-paper-icon-button[title="Previous song"]`;
-    await this.page.waitForSelector(previousSongSelector);
-    await this.page.click(previousSongSelector);
-  }
-
-  public async playPause() {
-    const playPauseSelector = `#play-pause-button`;
-    await this.page.waitForSelector(playPauseSelector);
-    await this.page.click(playPauseSelector);
   }
 }

--- a/src/yt-music/YTMusicSession.ts
+++ b/src/yt-music/YTMusicSession.ts
@@ -16,10 +16,20 @@ const YOUTUBE_MUSIC_URL = 'https://music.youtube.com/';
 export class YTMusicSession {
   public PlayUpdates: YTPlayUpdates;
 
+  /**
+   * A YTMusicSession instance manages all headless browsing of the Youtube Music website. A YTMusicSession must be instantiated asynchronously via the 'create' function.
+   * @param page An initialized Puppeteer page used to navigate Youtube music.
+   */
   private constructor(private page: Page) {
     this.PlayUpdates = new YTPlayUpdates(page, [(song) => console.log(song)]);
   }
 
+  /**
+   * Asynchronously creates an instance of a YTMusicSession. A YTMusicSession instance manages all headless browsing of the Youtube Music website.
+   * @param args Any search query arguments entered by the user. These will automatically initiate a search.
+   * @param sessionOptions Any additional options for the session.
+   * @returns An instance of a YTMusicSession.
+   */
   static async create(
     args?: string[],
     sessionOptions?: Partial<YTSessionOptions>
@@ -44,6 +54,11 @@ export class YTMusicSession {
     return session;
   }
 
+  /**
+   * Initiates a search of Youtube Music based on the args passed in.
+   * @param args A list of strings that will be concatenated with a '+' in the search URL
+   * @param ytSearchOptions Additional options for the search.
+   */
   public async search(
     args: string[],
     ytSearchOptions?: Partial<YTSearchOptions>

--- a/src/yt-music/YTMusicSession.ts
+++ b/src/yt-music/YTMusicSession.ts
@@ -1,3 +1,4 @@
+import { BrowserSession } from './../user-controls/BrowserSession';
 import {
   mergeDefaultYTSearchOptions,
   YTSearchOptions,
@@ -10,11 +11,13 @@ import {
   YTSessionOptions,
 } from './YTSessionOptions';
 import { YTPlayUpdates } from './YTPlayUpdates';
+import { YTMusicPlaybackControls } from './YTMusicPlaybackControls';
 
 const YOUTUBE_MUSIC_URL = 'https://music.youtube.com/';
 
-export class YTMusicSession {
+export class YTMusicSession implements BrowserSession {
   public PlayUpdates: YTPlayUpdates;
+  public PlaybackControls: YTMusicPlaybackControls;
 
   /**
    * A YTMusicSession instance manages all headless browsing of the Youtube Music website. A YTMusicSession must be instantiated asynchronously via the 'create' function.

--- a/src/yt-music/YTPlayUpdates.ts
+++ b/src/yt-music/YTPlayUpdates.ts
@@ -5,7 +5,7 @@ import {
 } from '../user-controls/PlayUpdates';
 
 export class YTPlayUpdates implements PlayUpdates {
-  private subscribers: PlayUpdateSubscriber[] = [];
+  private subscribers: PlayUpdateSubscriber[];
 
   private currentSong: string;
   private currentArtist: string;
@@ -23,7 +23,7 @@ export class YTPlayUpdates implements PlayUpdates {
    * @param initialSubscribers A list of subscribers that will be subscribed before any play updates.
    */
   constructor(private page: Page, initialSubscribers?: PlayUpdateSubscriber[]) {
-    this.subscribers = initialSubscribers;
+    this.subscribers = initialSubscribers || [];
     this.handlePlayUpdate();
   }
 

--- a/src/yt-music/YTPlayUpdates.ts
+++ b/src/yt-music/YTPlayUpdates.ts
@@ -5,22 +5,37 @@ type PlayUpdateSubscriber = (nowPlaying: string) => void;
 export class YTPlayUpdates {
   private subscribers: PlayUpdateSubscriber[] = [];
 
-  private currentSong: string = '';
-  private currentArtist: string = '';
+  private currentSong: string;
+  private currentArtist: string;
 
+  /**
+   * A formatted display string that indicates the current song and artist that is playing.
+   */
   public get nowPlaying() {
     return `${this.currentSong} | ${this.currentArtist}`;
   }
 
+  /**
+   * Manages the currently playing song of a YTMusicSession instance. Updates to the current song can be subscribed to and can be force-updated if needed.
+   * @param page The Puppeteer page instance of the YTMusicSession.
+   * @param initialSubscribers A list of subscribers that will be subscribed before any play updates.
+   */
   constructor(private page: Page, initialSubscribers?: PlayUpdateSubscriber[]) {
     this.subscribers = initialSubscribers;
     this.handlePlayUpdate();
   }
 
+  /**
+   * Subscribes to automatic updates of either the current song or current artist.
+   * @param callback A callback that will be invoked when the current song or artist changes. The callback may receive one argument - a formatted string indicating the new song and artist.
+   */
   public subscribe = (callback: PlayUpdateSubscriber) => {
     this.subscribers.push(callback);
   };
 
+  /**
+   * Forces an update to the current song. This is useful when the page first loads as the subscribers will automatically receive updates when the DOM changes but not when it is first initialized.
+   */
   public async forceSongUpdate() {
     await Promise.all([
       this.page.waitForSelector(`ytmusic-player-bar yt-formatted-string`),

--- a/src/yt-music/YTPlayUpdates.ts
+++ b/src/yt-music/YTPlayUpdates.ts
@@ -1,0 +1,87 @@
+import { Page } from 'puppeteer';
+
+type PlayUpdateSubscriber = (nowPlaying: string) => void;
+
+export class YTPlayUpdates {
+  private subscribers: PlayUpdateSubscriber[] = [];
+
+  private currentSong: string = '';
+  private currentArtist: string = '';
+
+  public get nowPlaying() {
+    return `${this.currentSong} | ${this.currentArtist}`;
+  }
+
+  constructor(private page: Page, initialSubscribers?: PlayUpdateSubscriber[]) {
+    this.subscribers = initialSubscribers;
+    this.handlePlayUpdate();
+  }
+
+  public subscribe = (callback: PlayUpdateSubscriber) => {
+    this.subscribers.push(callback);
+  };
+
+  public async forceSongUpdate() {
+    await Promise.all([
+      this.page.waitForSelector(`ytmusic-player-bar yt-formatted-string`),
+      this.page.waitForSelector(
+        `ytmusic-player-bar span.subtitle yt-formatted-string a`
+      ),
+    ]);
+
+    const [currentSong, currentArtist] = await Promise.all([
+      this.page.$eval(
+        `ytmusic-player-bar yt-formatted-string`,
+        (element: HTMLElement) => element.innerText
+      ),
+      this.page.$eval(
+        `ytmusic-player-bar span.subtitle yt-formatted-string a`,
+        (element: HTMLElement) => element.innerText
+      ),
+    ]);
+
+    this.currentSong = currentSong;
+    this.currentArtist = currentArtist;
+
+    this.subscribers.forEach((subscriber) => subscriber(this.nowPlaying));
+  }
+
+  private async handlePlayUpdate() {
+    await this.page.exposeFunction(
+      'handlePlayUpdate',
+      (newSongInfo: string, newArtistInfo: string) => {
+        this.currentSong = newSongInfo;
+        this.currentArtist = newArtistInfo;
+        this.subscribers.forEach((subscriber) => subscriber(this.nowPlaying));
+      }
+    );
+    await Promise.all([
+      this.page.waitForSelector(`ytmusic-player-bar yt-formatted-string`),
+      this.page.waitForSelector(
+        `ytmusic-player-bar span.subtitle yt-formatted-string a`
+      ),
+    ]);
+
+    await this.page.evaluate(() => {
+      const observer = new MutationObserver(() => {
+        const newSongElement: HTMLElement = document.querySelector(
+          `ytmusic-player-bar yt-formatted-string`
+        );
+        const newArtistElement: HTMLElement = document.querySelector(
+          `ytmusic-player-bar span.subtitle yt-formatted-string a`
+        );
+
+        //@ts-ignore
+        handlePlayUpdate(newSongElement.innerText, newArtistElement.innerText);
+      });
+      observer.observe(
+        document.querySelector(`ytmusic-player-bar yt-formatted-string`),
+        {
+          attributes: false,
+          childList: true,
+          subtree: true,
+        }
+      );
+    });
+  }
+}

--- a/src/yt-music/YTPlayUpdates.ts
+++ b/src/yt-music/YTPlayUpdates.ts
@@ -1,8 +1,10 @@
 import { Page } from 'puppeteer';
+import {
+  PlayUpdates,
+  PlayUpdateSubscriber,
+} from '../user-controls/PlayUpdates';
 
-type PlayUpdateSubscriber = (nowPlaying: string) => void;
-
-export class YTPlayUpdates {
+export class YTPlayUpdates implements PlayUpdates {
   private subscribers: PlayUpdateSubscriber[] = [];
 
   private currentSong: string;

--- a/src/yt-music/YTSessionOptions.ts
+++ b/src/yt-music/YTSessionOptions.ts
@@ -1,4 +1,7 @@
 export interface YTSessionOptions {
+  /**
+   * When set to true, the Chromium browser instance running Youtube Music will be headless (not rendered). Default is true.
+   */
   headless: boolean;
 }
 
@@ -6,6 +9,11 @@ export const defaultYTSessionOptions: YTSessionOptions = {
   headless: true,
 };
 
+/**
+ * Merges any passed in YTSessionOptions with the default, overriding any default options.
+ * @param sessionOptions A partial object containing the default properties that should be overriden.
+ * @returns An updated complete YTSessionOptions object with all properties assigned.
+ */
 export const mergeDefaultYTSessionOptions = (
   sessionOptions: Partial<YTSessionOptions>
 ): YTSessionOptions => {


### PR DESCRIPTION
Added external class YTPlayUpdates which manages updates to the current playing song and artist and manages subscriptions to these updates.

MutationObservers are used to track changes to the headless browser song title and artist. Updates invoke all subscribed callbacks.